### PR TITLE
Test at lowest dependencies installed

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -127,3 +127,61 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  tests-lowest:
+    runs-on: ubuntu-latest
+
+    env:
+      WIREMOCK_HOST: http://localhost:8080
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: xdebug
+
+      - name: Install Composer dependencies
+        run: composer install --no-progress --prefer-lowest
+
+      - name: Run WireMock
+        run: docker compose up -d wiremock
+
+      - name: Wait for Wiremock
+        run: |
+          curl --retry 5 --retry-delay 3 --retry-all-errors $WIREMOCK_HOST/__admin/health
+
+      - name: Run Pest tests
+        run: XDEBUG_MODE=coverage vendor/bin/pest --coverage --min=90 --coverage-cobertura coverage/coverage.cobertura.xml
+
+      - name: Show Wiremock logs
+        if: always()
+        run: docker compose logs wiremock
+
+      - name: Docker Compose Down
+        if: always()
+        run: docker compose down
+
+      - name: Code Coverage Report
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: coverage/coverage.cobertura.xml
+          badge: true
+          fail_below_min: true
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: true
+          indicators: true
+          output: both
+          thresholds: '90 95'
+
+      - name: Write to Job Summary
+        run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -145,7 +145,7 @@ jobs:
           coverage: xdebug
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --prefer-lowest
+        run: composer update --no-progress --prefer-lowest
 
       - name: Run WireMock
         run: docker compose up -d wiremock

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -155,7 +155,7 @@ jobs:
           curl --retry 5 --retry-delay 3 --retry-all-errors $WIREMOCK_HOST/__admin/health
 
       - name: Run Pest tests
-        run: XDEBUG_MODE=coverage vendor/bin/pest --coverage --min=90 --coverage-cobertura coverage/coverage.cobertura.xml
+        run: vendor/bin/pest
 
       - name: Show Wiremock logs
         if: always()
@@ -164,24 +164,3 @@ jobs:
       - name: Docker Compose Down
         if: always()
         run: docker compose down
-
-      - name: Code Coverage Report
-        uses: irongut/CodeCoverageSummary@v1.3.0
-        with:
-          filename: coverage/coverage.cobertura.xml
-          badge: true
-          fail_below_min: true
-          format: markdown
-          hide_branch_rate: false
-          hide_complexity: true
-          indicators: true
-          output: both
-          thresholds: '90 95'
-
-      - name: Write to Job Summary
-        run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     ],
     "require": {
         "php": "^8.3",
-        "guzzlehttp/guzzle": "^7.0",
-        "symfony/serializer": "^7.0",
+        "guzzlehttp/guzzle": "^7.8",
+        "symfony/serializer": "^7.2",
         "symfony/property-info": "^7.2",
         "symfony/property-access": "^7.2",
         "psr/log": "^3.0"


### PR DESCRIPTION
In order to verify the package works as expected with lower versions of packages installed the github workflow should test against the `--prefer-lowest` vendors.